### PR TITLE
[draft] fix go mod tidy and remove unnecessary parentheses

### DIFF
--- a/commands/go-mod-tidy.go
+++ b/commands/go-mod-tidy.go
@@ -9,7 +9,7 @@ var goModTidy = &cobra.Command{
 	Short: "Prune no-longer required commits from go.mod",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		runTool("go", []string{"mod", "tidy"})
+		runTool("go", append([]string{"mod", "tidy"}))
 	},
 }
 

--- a/commands/golangci-lint.go
+++ b/commands/golangci-lint.go
@@ -10,7 +10,7 @@ var golangciLint = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		runTool("golangci-lint", append([]string{"run"}, pkgNames(dirNames((args)))...))
+		runTool("golangci-lint", append([]string{"run"}, pkgNames(dirNames(args))...))
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lietu/go-pre-commit
+module github.com/dotX12/go-pre-commit
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dotX12/go-pre-commit
+module github.com/lietu/go-pre-commit
 
 go 1.13
 


### PR DESCRIPTION
- fix `go mod tidy`
- remove unnecessary parentheses in [golangci-lint.go](https://github.com/lietu/go-pre-commit/compare/master...dotX12:go-pre-commit:master#diff-704ef908495d994448ec581860b808642b6c7f5ded027057e3d793aa9617c476)