### PR TITLE
fix go mod tidy and remove unnecessary parentheses

### DIFF
--- a/commands/go-mod-tidy.go
+++ b/commands/go-mod-tidy.go
@@ -9,7 +9,7 @@ var goModTidy = &cobra.Command{
 	Short: "Prune no-longer required commits from go.mod",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		runTool("go", []string{"mod", "tidy"})
+		runTool("go", append([]string{"mod", "tidy"}))
 	},
 }
 

--- a/commands/golangci-lint.go
+++ b/commands/golangci-lint.go
@@ -10,7 +10,7 @@ var golangciLint = &cobra.Command{
 	Long:  ``,
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		runTool("golangci-lint", append([]string{"run"}, pkgNames(dirNames((args)))...))
+		runTool("golangci-lint", append([]string{"run"}, pkgNames(dirNames(args))...))
 	},
 }
 


### PR DESCRIPTION
Fix https://github.com/lietu/go-pre-commit/pull/2#pullrequestreview-638206165

How reproduce:
`pre-commit run --all-files`

Before (spamming):
```
go: 'go mod tidy' accepts no arguments
go: 'go mod tidy' accepts no arguments
go: 'go mod tidy' accepts no arguments
go: 'go mod tidy' accepts no arguments
go: 'go mod tidy' accepts no arguments
```
After:
`go-mod-tidy..............................................................Passed`